### PR TITLE
Fix AMP for memory optimized options

### DIFF
--- a/megablocks/layers/glu.py
+++ b/megablocks/layers/glu.py
@@ -50,6 +50,12 @@ class MemoryOptimizedGroupedGLU(torch.autograd.Function):
     @staticmethod
     @torch.cuda.amp.custom_fwd
     def forward(ctx, x, w1, v1, w2, batch_sizes, activation_fn):
+        # Cast inputs using ctx dtype from AMP
+        if ctx._fwd_used_autocast:
+            x = x.to(ctx._dtype)
+            w1 = w1.to(ctx._dtype)
+            v1 = v1.to(ctx._dtype)
+            w2 = w2.to(ctx._dtype)
         # x: [m, k], w1: [n, k], v1: [n, k], w2: [n, k]
         if (not x.is_contiguous() or not w1.is_contiguous() or
             not v1.is_contiguous() or not w2.is_contiguous()):

--- a/megablocks/layers/mlp.py
+++ b/megablocks/layers/mlp.py
@@ -169,6 +169,11 @@ class MemoryOptimizedMLP(torch.autograd.Function):
     @staticmethod
     @torch.cuda.amp.custom_fwd
     def forward(ctx, x, w1, w2, topo, activation_fn):
+        # Cast inputs using ctx dtype from AMP
+        if ctx._fwd_used_autocast:
+            x = x.to(ctx._dtype)
+            w1 = w1.to(ctx._dtype)
+            w2 = w2.to(ctx._dtype)
         # x: [m, k], w1: [n, k], w2: [n, k]
         if (not x.is_contiguous() or not w1.is_contiguous() or
             not w2.is_contiguous()):
@@ -360,6 +365,11 @@ class MemoryOptimizedGroupedMLP(torch.autograd.Function):
     @staticmethod
     @torch.cuda.amp.custom_fwd
     def forward(ctx, x, w1, w2, batch_sizes, activation_fn):
+        # Cast inputs using ctx dtype from AMP
+        if ctx._fwd_used_autocast:
+            x = x.to(ctx._dtype)
+            w1 = w1.to(ctx._dtype)
+            w2 = w2.to(ctx._dtype)
         # x: [m, k], w1: [n, k], w2: [n, k]
         if (not x.is_contiguous() or not w1.is_contiguous() or
             not w2.is_contiguous()):

--- a/megablocks/layers/weight_parallel.py
+++ b/megablocks/layers/weight_parallel.py
@@ -65,6 +65,10 @@ class WeightParallelSddNt(torch.autograd.Function):
     @staticmethod
     @torch.cuda.amp.custom_fwd
     def forward(ctx, x, w, topo, group):
+        # Cast inputs using ctx dtype from AMP
+        if ctx._fwd_used_autocast:
+            x = x.to(ctx._dtype)
+            w = w.to(ctx._dtype)
         # [m, k] x [n, k] = [m, n]
         if not x.is_contiguous() or not w.is_contiguous():
             raise ValueError("Expected contiguous 'x' and 'w'.")
@@ -140,6 +144,10 @@ class WeightParallelDsdNn(torch.autograd.Function):
                 w,
                 group):
         # [m, k] x [k, n] = [m, n]
+        # Cast inputs using ctx dtype from AMP
+        if ctx._fwd_used_autocast:
+            data = data.to(ctx._dtype)
+            w = w.to(ctx._dtype)
         if not data.is_contiguous() or not w.is_contiguous():
             raise ValueError("Expected contiguous 'data' and 'w'.")
 
@@ -216,6 +224,11 @@ class MemoryOptimizedWeightParallelMLP(torch.autograd.Function):
     @staticmethod
     @torch.cuda.amp.custom_fwd
     def forward(ctx, x, w1, w2, topo, group):
+        # Cast inputs using ctx dtype from AMP
+        if ctx._fwd_used_autocast:
+            x = x.to(ctx._dtype)
+            w1 = w1.to(ctx._dtype)
+            w2 = w2.to(ctx._dtype)
         # x: [m, k], w1: [n, k], w2: [n, k]
         if (not x.is_contiguous() or not w1.is_contiguous() or
             not w2.is_contiguous()):


### PR DESCRIPTION
Correctly casts inputs/weights in right precision for AMP, which may not operate correctly otherwise