### PR TITLE
dont save moe lb-loss tensors if args.moe_loss_weight=0

### DIFF
--- a/megablocks/layers/moe.py
+++ b/megablocks/layers/moe.py
@@ -29,6 +29,9 @@ def clear_load_balancing_loss():
 
 
 def batched_load_balancing_loss(args : Arguments):
+    if args.moe_loss_weight == 0:
+        return 0.0
+
     # tokens_per_expert[i].shape = (num_experts)
     # expert_scores[i].shape = (tokens, num_experts)
     tokens_per_expert, expert_scores = zip(*get_load_balancing_loss())
@@ -424,7 +427,7 @@ class ParallelMLP(torch.nn.Module):
         # Compute the experts.
         x, tokens_per_expert = self.forward_fn(
             x, expert_weights, top_experts)
-        if self.training:
+        if self.training and self.args.moe_loss_weight > 0:
             save_load_balancing_loss((tokens_per_expert, scores))
         x = x.view(in_shape)
         if self.bias is not None:


### PR DESCRIPTION
Megablocks accumulates lb-loss tensors [here](https://github.com/databricks/megablocks/blob/main/megablocks/layers/moe.py#L428) and expects the user to call `clear_load_balancing_loss()` to release the memory.  In our case we compute the lb-loss outside of Megablocks and had a GPU memory leak before we noticed this behaviour.
We can call `clear_load_balancing_loss()` after every Megablocks `forward()`, but it's even better to just avoid accumulating these tensors if Megablocks' lb-loss calculation is not needed - which can already be signaled by passing 0 to `Arguments.args.moe_loss_weight`
