### PR TITLE
fix eval for moe layer

### DIFF
--- a/megablocks/layers/moe.py
+++ b/megablocks/layers/moe.py
@@ -430,7 +430,7 @@ class ParallelMLP(torch.nn.Module):
         # Compute the experts.
         x, tokens_per_expert = self.forward_fn(
             x, expert_weights, top_experts)
-        if self.training and self.args.moe_loss_weight > 0:
+        if self.args.moe_loss_weight > 0:
             save_load_balancing_loss((tokens_per_expert, scores))
         x = x.view(in_shape)
         if self.bias is not None:


### PR DESCRIPTION
when I run /exp/dmoe/dmoe_46m_8gpu.sh，I encountered the following Error during evaluation.
![image](https://github.com/user-attachments/assets/21b98faa-b7f2-4146-8bbf-fb7d292cde95)

the func **save_load_balancing_loss** is bypassed during evaluation.
