### PR TITLE
Change Runner in GA

### DIFF
--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   pytest-gpu:
     name: ${{ matrix.name }}
-    runs-on: linux-ubuntu-latest
+    runs-on: ubuntu-latest # todo: switch to linux-ubuntu-latest later
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Change the runner from `linux-ubuntu-latest`, one of our runners, to the default Github Runner `ubutnu-latest`. This is because to use `linux-ubuntu-latest` we need the repo to be on the IP allow list and we don't have that right now.