### PR TITLE
only run GA if repo owner is Databricks

### DIFF
--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   pytest-gpu:
     name: ${{ matrix.name }}
+    if: github.repository_owner == 'databricks'
     runs-on: ubuntu-latest # todo: switch to linux-ubuntu-latest later
     strategy:
       fail-fast: false


### PR DESCRIPTION
[LLM-Foundry](https://github.com/mosaicml/llm-foundry/blob/6dcc18a5d1db104b48eacce68144db5a99da37d7/.github/workflows/pr-gpu.yaml#L19) only runs this GA if the repo owner is Databricks. I added this to make things consistent.