### PR TITLE
Implement Router Z-loss

### DIFF
--- a/megablocks/layers/arguments.py
+++ b/megablocks/layers/arguments.py
@@ -68,6 +68,10 @@ class Arguments:
         int] = None  # hidden size of the shared expert IF we want to set it to something different from hidden_size
     shared_expert_weighted_sum: bool = False  # enable using weighted sum for shared expert output (wieghted by number of experts used)
 
+    # Router Z-loss arguments
+    moe_zloss_weight: float = 0 # 1e-3 is a reasonable value
+    moe_zloss_in_fp32 : bool = False
+
     def __post_init__(self):
         if self.__getattribute__('mlp_impl') == 'grouped':
             grouped_gemm.assert_grouped_gemm_is_available()

--- a/megablocks/layers/arguments.py
+++ b/megablocks/layers/arguments.py
@@ -69,8 +69,8 @@ class Arguments:
     shared_expert_weighted_sum: bool = False  # enable using weighted sum for shared expert output (wieghted by number of experts used)
 
     # Router Z-loss arguments
-    moe_zloss_weight: float = 0 # 1e-3 is a reasonable value
-    moe_zloss_in_fp32 : bool = False
+    moe_zloss_weight: float = 0  # 1e-3 is a reasonable value
+    moe_zloss_in_fp32: bool = False
 
     def __post_init__(self):
         if self.__getattribute__('mlp_impl') == 'grouped':

--- a/megablocks/layers/router.py
+++ b/megablocks/layers/router.py
@@ -9,22 +9,25 @@ from megablocks.layers.arguments import Arguments
 
 _ROUTER_LOGITS = []
 
+
 def _save_router_logits(logits: torch.Tensor, args: Arguments):
     if args.moe_zloss_weight == 0:
         return
     global _ROUTER_LOGITS
     _ROUTER_LOGITS.append(logits)
 
+
 def clear_router_zloss():
     global _ROUTER_LOGITS
     _ROUTER_LOGITS.clear()
 
-def batched_router_zloss(args : Arguments):
+
+def batched_router_zloss(args: Arguments):
     global _ROUTER_LOGITS
 
     if args.moe_zloss_weight == 0:
         import warnings
-        warnings.warn("Call to batched_router_zloss, but moe_zloss_weight=0")
+        warnings.warn('Call to batched_router_zloss, but moe_zloss_weight=0')
         return 0
 
     logits_per_router = _ROUTER_LOGITS
@@ -33,8 +36,7 @@ def batched_router_zloss(args : Arguments):
         logits_per_router = [logits.float() for logits in logits_per_router]
 
     unscaled_zloss_per_router = torch.stack([
-        torch.logsumexp(logits, dim=1).square().mean()
-        for logits in logits_per_router
+        torch.logsumexp(logits, dim=1).square().mean() for logits in logits_per_router
     ])
 
     return args.moe_zloss_weight * unscaled_zloss_per_router


### PR DESCRIPTION
# What does this PR do?

Z-loss is an additional term that improves the stability of softmax logit inputs by penalizing large values where the float precision is reduced.

Idea was introduced by the ST-MoE Paper - https://arxiv.org/abs/2202.08906. And has been recently used in the OLMoE work - https://arxiv.org/abs/2409.02060.

# What issue(s) does this change relate to?

Alternative implementation of https://github.com/databricks/megablocks/pull/133 

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/databricks/megablocks/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
  - Unsure where to document things
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/databricks/megablocks/blob/dev/CONTRIBUTING.md#running-tests))
  - Added a `test_moe_forward_backward_with_zloss` and `test_moe_forward_backward_with_zloss`
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/databricks/megablocks/blob/dev/CONTRIBUTING.md#prerequisites))

