### PR TITLE
Initialize default device lazily

### DIFF
--- a/megablocks/layers/arguments.py
+++ b/megablocks/layers/arguments.py
@@ -52,7 +52,7 @@ class Arguments:
     # Initialization arguments.
     fp16: bool = True
     bf16: bool = False
-    device: Union[int, torch.device] = torch.cuda.current_device()
+    device: Union[int, torch.device] = dataclasses.field(default_factory=torch.cuda.current_device)
     init_method: InitFn = partial(torch.nn.init.normal_, mean=0.0, std=0.02)
     output_layer_init_method: InitFn = init_method
 


### PR DESCRIPTION
This way, we can import the library without requiring a GPU to be present.

# What does this PR do?

Do not query the `torch.cuda.current_device()` upon importing the library. Instead, query it when we actually instantiate the arguments struct.

# What issue(s) does this change relate to?

Not submitted.

# Before submitting
- [X] Have you read the [contributor guidelines](https://github.com/databricks/megablocks/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/databricks/megablocks/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [X] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/databricks/megablocks/blob/dev/CONTRIBUTING.md#prerequisites))