### PR TITLE
Updated pytorch and disabled sparse tests

### DIFF
--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -4,7 +4,7 @@ on:
     branches:
     - main
     - release/*
-  pull_request_target:
+  pull_request:
     branches:
     - main
     - release/**

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -4,7 +4,7 @@ on:
     branches:
     - main
     - release/*
-  pull_request:
+  pull_request_target:
     branches:
     - main
     - release/**

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -21,14 +21,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - name: "python3.11-pytorch2.5.1-gpus1"
+        - name: "python3.11-pytorch2.6.0-gpus1"
           gpu_num: 1
           python_version: 3.11
-          container: mosaicml/pytorch:2.5.1_cu124-python3.11-ubuntu20.04
-        - name: "python3.11-pytorch2.5.1-gpus2"
+          container: mosaicml/pytorch:2.6.0_cu124-python3.11-ubuntu22.04
+        - name: "python3.11-pytorch2.6.0-gpus2"
           gpu_num: 2
           python_version: 3.11
-          container: mosaicml/pytorch:2.5.1_cu124-python3.11-ubuntu20.04
+          container: mosaicml/pytorch:2.6.0_cu124-python3.11-ubuntu22.04
     steps:
     - name: Run PR GPU tests
       uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.1.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     additional_dependencies:
     - toml
 - repo: https://github.com/hadialqattan/pycln
-  rev: v2.1.2
+  rev: v2.5.0
   hooks:
   - id: pycln
     args: [. --all]

--- a/megablocks/layers/arguments.py
+++ b/megablocks/layers/arguments.py
@@ -79,7 +79,9 @@ class Arguments:
             try:
                 import triton
                 if triton.__version__ >= '3.2.0':
-                    raise ValueError('Sparse MLP is not supported with triton >=3.2.0')
+                    raise ValueError(
+                        'Sparse MLP is not supported with triton >=3.2.0. Please use mlp_impl="grouped" instead.',
+                    )
             except ImportError:
                 raise ImportError('Triton is required for sparse MLP implementation')
 

--- a/megablocks/layers/arguments.py
+++ b/megablocks/layers/arguments.py
@@ -81,7 +81,7 @@ class Arguments:
                 if triton.__version__ >= '3.2.0':
                     raise ValueError('Sparse MLP is not supported with triton >=3.2.0')
             except ImportError:
-                raise ImportError("Triton is required for sparse MLP implementation")
+                raise ImportError('Triton is required for sparse MLP implementation')
 
         if self.__getattribute__('mlp_impl') == 'grouped':
             grouped_gemm.assert_grouped_gemm_is_available()

--- a/megablocks/layers/arguments.py
+++ b/megablocks/layers/arguments.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Optional, Union
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
+import triton
 
 import megablocks.grouped_gemm_util as grouped_gemm
 
@@ -73,6 +74,11 @@ class Arguments:
     moe_zloss_in_fp32: bool = False
 
     def __post_init__(self):
+        # Sparse MLP is not supported with triton >=3.2.0
+        # TODO: Remove this once sparse is supported with triton >=3.2.0
+        if self.__getattribute__('mlp_impl') == 'sparse' and triton.__version__ >= '3.2.0':
+            raise ValueError('Sparse MLP is not supported with triton >=3.2.0')
+
         if self.__getattribute__('mlp_impl') == 'grouped':
             grouped_gemm.assert_grouped_gemm_is_available()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 # build requirements
 [build-system]
-requires = ["setuptools < 70.0.0", "torch >= 2.5.1, < 2.5.2"]
+requires = ["setuptools < 70.0.0", "torch >= 2.6.0, < 2.6.1"]
 build-backend = "setuptools.build_meta"
 
 # Pytest

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,8 @@ classifiers = [
 install_requires = [
     'numpy>=1.21.5,<2.1.0',
     'packaging>=21.3.0,<24.2',
-    'torch>=2.5.1,<2.5.2',
-    'triton>=2.1.0',
+    'torch>=2.6.0,<2.6.1',
+    'triton>=3.2.0,<3.3.0',
     'stanford-stk==0.7.1',
 ]
 

--- a/tests/layers/dmoe_test.py
+++ b/tests/layers/dmoe_test.py
@@ -5,7 +5,6 @@ from functools import partial
 
 import pytest
 import torch
-import triton
 
 from megablocks import grouped_gemm_util as gg
 from megablocks.layers.arguments import Arguments
@@ -56,8 +55,13 @@ def construct_moes(
 ):
     # All tests are skipped if triton >=3.2.0 is installed since sparse is not supported
     # TODO: Remove this once sparse is supported with triton >=3.2.0
-    if mlp_impl == 'sparse' and triton.__version__ >= '3.2.0':
-        pytest.skip('Sparse MLP is not supported with triton >=3.2.0')
+    if mlp_impl == 'sparse':
+        try:
+            import triton
+            if triton.__version__ >= '3.2.0':
+                pytest.skip('Sparse MLP is not supported with triton >=3.2.0')
+        except ImportError:
+            pass
 
     init_method = partial(torch.nn.init.normal_, mean=0.0, std=0.1)
     args = Arguments(

--- a/tests/layers/dmoe_test.py
+++ b/tests/layers/dmoe_test.py
@@ -5,6 +5,7 @@ from functools import partial
 
 import pytest
 import torch
+import triton
 
 from megablocks import grouped_gemm_util as gg
 from megablocks.layers.arguments import Arguments
@@ -53,6 +54,11 @@ def construct_moes(
     mlp_impl: str = 'sparse',
     moe_zloss_weight: float = 0,
 ):
+    # All tests are skipped if triton >=3.2.0 is installed since sparse is not supported
+    # TODO: Remove this once sparse is supported with triton >=3.2.0
+    if mlp_impl == 'sparse' and triton.__version__ >= '3.2.0':
+        pytest.skip('Sparse MLP is not supported with triton >=3.2.0')
+
     init_method = partial(torch.nn.init.normal_, mean=0.0, std=0.1)
     args = Arguments(
         hidden_size=hidden_size,

--- a/tests/layers/glu_test.py
+++ b/tests/layers/glu_test.py
@@ -6,6 +6,7 @@ from functools import partial
 import pytest
 import stk
 import torch
+import triton
 
 from megablocks.layers import dmlp_registry
 from megablocks.layers.arguments import Arguments
@@ -23,6 +24,11 @@ def construct_dmoe_glu(
     mlp_impl: str = 'sparse',
     memory_optimized_mlp: bool = False,
 ):
+    # All tests are skipped if triton >=3.2.0 is installed since sparse is not supported
+    # TODO: Remove this once sparse is supported with triton >=3.2.0
+    if mlp_impl == 'sparse' and triton.__version__ >= '3.2.0':
+        pytest.skip('Sparse MLP is not supported with triton >=3.2.0')
+
     init_method = partial(torch.nn.init.normal_, mean=0.0, std=0.1)
     args = Arguments(
         hidden_size=hidden_size,

--- a/tests/layers/glu_test.py
+++ b/tests/layers/glu_test.py
@@ -6,7 +6,6 @@ from functools import partial
 import pytest
 import stk
 import torch
-import triton
 
 from megablocks.layers import dmlp_registry
 from megablocks.layers.arguments import Arguments
@@ -26,8 +25,13 @@ def construct_dmoe_glu(
 ):
     # All tests are skipped if triton >=3.2.0 is installed since sparse is not supported
     # TODO: Remove this once sparse is supported with triton >=3.2.0
-    if mlp_impl == 'sparse' and triton.__version__ >= '3.2.0':
-        pytest.skip('Sparse MLP is not supported with triton >=3.2.0')
+    if mlp_impl == 'sparse':
+        try:
+            import triton
+            if triton.__version__ >= '3.2.0':
+                pytest.skip('Sparse MLP is not supported with triton >=3.2.0')
+        except ImportError:
+            pass
 
     init_method = partial(torch.nn.init.normal_, mean=0.0, std=0.1)
     args = Arguments(

--- a/tests/layers/moe_test.py
+++ b/tests/layers/moe_test.py
@@ -5,7 +5,6 @@ from functools import partial
 
 import pytest
 import torch
-import triton
 
 from megablocks.layers.arguments import Arguments
 from megablocks.layers.moe import MoE, batched_load_balancing_loss, clear_load_balancing_loss
@@ -44,8 +43,12 @@ def construct_moe(
 ):
     # All tests are skipped if triton >=3.2.0 is installed since sparse is not supported
     # TODO: Remove this once sparse is supported with triton >=3.2.0
-    if triton.__version__ >= '3.2.0':
-        pytest.skip('Sparse MLP is not supported with triton >=3.2.0')
+    try:
+        import triton
+        if triton.__version__ >= '3.2.0':
+            pytest.skip('Sparse MLP is not supported with triton >=3.2.0')
+    except ImportError:
+        pass
 
     init_method = partial(torch.nn.init.normal_, mean=0.0, std=0.1)
     args = Arguments(

--- a/tests/layers/moe_test.py
+++ b/tests/layers/moe_test.py
@@ -5,6 +5,7 @@ from functools import partial
 
 import pytest
 import torch
+import triton
 
 from megablocks.layers.arguments import Arguments
 from megablocks.layers.moe import MoE, batched_load_balancing_loss, clear_load_balancing_loss
@@ -41,6 +42,11 @@ def construct_moe(
     moe_top_k: int = 1,
     moe_zloss_weight: float = 0,
 ):
+    # All tests are skipped if triton >=3.2.0 is installed since sparse is not supported
+    # TODO: Remove this once sparse is supported with triton >=3.2.0
+    if triton.__version__ >= '3.2.0':
+        pytest.skip('Sparse MLP is not supported with triton >=3.2.0')
+
     init_method = partial(torch.nn.init.normal_, mean=0.0, std=0.1)
     args = Arguments(
         hidden_size=hidden_size,


### PR DESCRIPTION
# What does this PR do?

Updated PyTorch like in https://github.com/databricks/megablocks/pull/167, but also disabling `sparse` support (only supporting `grouped` support) until we fix the issue with `triton`. Also updated `pycln` version that's breaking pre-commit checks.

For full context:

`triton 3.2.0` introduced some change to how it handles dtype promotion when two binary operands have different dtypes, and as a result we're encountering an int16 overflow in the `stk` dependency of megablocks which results in an illegal memory access (IMA). A fix like https://github.com/stanford-futuredata/stk/pull/17/files needs to be applied to to stk instead of megablocks or triton to resolve this initial issue. Even if we don't hit an IMA, not having this casting will lead to different outputs in `triton 3.1` and `triton 3.2` given the same inputs.