### PR TITLE
set default value of mlp_impl to grouped in layers/arguments

### DIFF
--- a/megablocks/layers/arguments.py
+++ b/megablocks/layers/arguments.py
@@ -47,7 +47,7 @@ class Arguments:
     # Compute arguments.
     memory_optimized_mlp: bool = False
     mlp_type: str = 'mlp'
-    mlp_impl: str = 'sparse'
+    mlp_impl: str = 'grouped'
 
     # Initialization arguments.
     fp16: bool = True


### PR DESCRIPTION
# What does this PR do?

Sets the default value of `mlp_impl` to `grouped` in `megablocks/layers/arguments/Arguments` dataclass.

This is done to avoid the default dmoe script in `exp/dmoe/dmoe_46m_8gpu.sh` to crash with:

```
[rank0]:   File "/home/mark/codes/megablocks/megablocks/layers/arguments.py", line 82, in __post_init__
[rank0]:     raise ValueError(
[rank0]: ValueError: Sparse MLP is not supported with triton >=3.2.0. Please use mlp_impl="grouped" instead.
```

# What issue(s) does this change relate to?

Fixes #170 

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/databricks/megablocks/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/databricks/megablocks/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/databricks/megablocks/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to MegaBlocks! We really appreciate it :)
-->
